### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -6,6 +6,7 @@ metadata:
   description: TypeScript Node SDK for Bandwidth Voice & Messaging
   annotations:
     github.com/project-slug: Bandwidth/node-sdk
+    bandwidth.com/languages: Node.js
   organization: BW
   costCenter: UNKNOWN
   platformType: 


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Node.js`